### PR TITLE
Update TANK.md

### DIFF
--- a/TANK.md
+++ b/TANK.md
@@ -23,7 +23,7 @@ done
 `docker.for.mac.localhost`:
 
 ```bash
-sed -i s/127.0.0.1:80/docker.for.mac.localhost:8000/g load/load_*.ini
+sed -i '' s/127.0.0.1:80/docker.for.mac.localhost/g load/load_*.ini
 ```
 
 ### Overload


### PR DESCRIPTION
В Mac OS после "-i" обязательный параметр, поэтому надо добавить '' 
docker.for.mac.localhost:8000 не работает, работает просто docker.for.mac.localhost